### PR TITLE
Be safer with pointer-to-slice conversions.

### DIFF
--- a/map_unix.go
+++ b/map_unix.go
@@ -8,23 +8,21 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-type slice struct {
-	addr unsafe.Pointer
-	len  int
-	cap  int
-}
-
 func mmap(size uint) (unsafe.Pointer, error) {
 	b, err := unix.Mmap(-1, 0, int(size), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANONYMOUS)
 	if err != nil {
 		return nil, err
 	}
-	sl := (*slice)(unsafe.Pointer(&b))
-	return sl.addr, nil
+	return unsafe.Pointer(&b[0]), nil
 }
 
 func munmap(p unsafe.Pointer) error {
 	size := int(((*header)(p)).size + szheader)
-	b := *(*[]byte)(unsafe.Pointer(&slice{p, size, size}))
+	var sl = struct {
+		addr unsafe.Pointer
+		len  int
+		cap  int
+	}{p, size, size}
+	b := *(*[]byte)(unsafe.Pointer(&sl))
 	return unix.Munmap(b)
 }


### PR DESCRIPTION
Converting a slice to any other struct type besides reflect.SliceHeader
is not guaranteed. Simplify the conversion to unsafe.Pointer in mmap by
taking the address of the first element. Additionally, declare the slice
header struct inline in munmap, since it isn't used in mmap anymore.
Revisit the implementation of munmap once https://github.com/golang/go/issues/19367 is resolved.